### PR TITLE
Invalid typo3/cms-core requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "license": "GPL-2.0+",
   "require": {
-    "typo3/cms-core": "8^"
+    "typo3/cms-core": "^8"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
It looks the composer requirement of typo3/cms-core is returning an error.

```
Skipped branch master, Could not parse version constraint 8^: Invalid version string "8^"

  [Composer\Repository\InvalidRepositoryException]
  No valid composer.json was found in any branch or tag of https://github.com/Apen/additional_reports.git, could n
  ot load a package from it.
```

Rather use:

```
require {
  "typo3/cms-core": "^8",
}
```