### PR TITLE
[FEAT] check if php function get_loaded_extensions is enabled

### DIFF
--- a/Classes/Reports/Status.php
+++ b/Classes/Reports/Status.php
@@ -158,9 +158,12 @@ class Status extends AbstractReport
             $data['apache_user'] = $apacheUser['name'] . ' (' . $apacheUser['gid'] . ')';
             $data['apache_group'] = $apacheGroup['name'] . ' (' . $apacheGroup['gid'] . ')';
         }
-        $extensions = array_map('strtolower', get_loaded_extensions());
-        natcasesort($extensions);
-        $data['extensions'] = $extensions;
+
+        if (function_exists('get_loaded_extensions')) {
+            $extensions = array_map('strtolower', get_loaded_extensions());
+            natcasesort($extensions);
+            $data['extensions'] = $extensions;
+        }
 
         $view->assign('datas_php', $data);
     }


### PR DESCRIPTION
Hej there,

within our TYPO3 server a lot of php functions are disabled for security reasons. Therefore we're getting the following error while calling the status report:

``` Call to undefined function Sng\AdditionalReports\Reports\get_loaded_extensions() ```