### PR TITLE
GeneralUtility::getFilesInDir(): Argument #5 ($excludePattern)

### DIFF
--- a/Classes/Utility.php
+++ b/Classes/Utility.php
@@ -203,7 +203,7 @@ class Utility
                             $currentExt['extkey'] = $extKey;
                             $currentExt['installed'] = ExtensionManagementUtility::isLoaded($extKey);
                             $currentExt['EM_CONF'] = $emConf;
-                            $currentExt['files'] = GeneralUtility::getFilesInDir($path . $extKey, '', 0, '', null);
+                            $currentExt['files'] = GeneralUtility::getFilesInDir($path . $extKey);
                             $currentExt['lastversion'] = Utility::checkExtensionUpdate($currentExt);
 
                             // db infos


### PR DESCRIPTION
`TYPO3\CMS\Core\Utility\GeneralUtility::getFilesInDir(): Argument #5 ($excludePattern) must be of type string, null given, called in /var/www/vhosts/hosting105782.a2f0c.netcup.net/httpdocs/test.decoderdb.de/typo3conf/ext/additional_reports/Classes/Utility.php on line 206`

TYPO3 13.4.5
PHP 8.3.16